### PR TITLE
Add CODEOWNERS file for code review enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,32 @@
+# CODEOWNERS file for Weave
+# This file defines who should review changes to specific parts of the codebase
+# 
+# For more information about CODEOWNERS files, see:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global ownership - all files require review from @ahsanazmi1
+*                 @ahsanazmi1
+
+# Source code ownership
+/src/            @ahsanazmi1
+
+# Test code ownership  
+/tests/          @ahsanazmi1
+
+# GitHub configuration ownership
+/.github/        @ahsanazmi1
+
+# Documentation ownership
+/docs/           @ahsanazmi1
+
+# Configuration files ownership
+/config/         @ahsanazmi1
+
+# Database files ownership
+*.db             @ahsanazmi1
+*.sqlite         @ahsanazmi1
+*.sqlite3        @ahsanazmi1
+
+# Project configuration files ownership
+pyproject.toml   @ahsanazmi1
+README.md        @ahsanazmi1


### PR DESCRIPTION
- Define code ownership rules for all repository paths
- Require @ahsanazmi1 review for all changes
- Enable branch protection rules to enforce CODEOWNERS reviews
- Cover all critical directories: /src/, /tests/, /.github/, /docs/, /config/
- Include specific ownership for database files (*.db, *.sqlite, *.sqlite3)
- Ensure comprehensive code review coverage across the Weave codebase